### PR TITLE
Introduced support of modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,5 +85,6 @@ lazy val `test-project`: Project = project.
   enablePlugins(ScalaJSJUnitPlugin).
   settings(
     scalaJSUseMainModuleInitializer := true,
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
     jsEnv := new net.exoego.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
   )

--- a/test-project/src/main/scala/testproject/OsArch.scala
+++ b/test-project/src/main/scala/testproject/OsArch.scala
@@ -1,0 +1,10 @@
+package testproject
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@JSImport("os", "arch")
+@js.native
+object OsArch extends js.Object {
+  def apply(): String = js.native
+}

--- a/test-project/src/test/scala/testproject/LibTest.scala
+++ b/test-project/src/test/scala/testproject/LibTest.scala
@@ -11,4 +11,8 @@ class LibTest {
     Lib.appendDocument("foo")
     assertEquals(1, count - oldCount)
   }
+
+  @Test def osArch_should_works(): Unit = {
+    assertNotNull(OsArch())
+  }
 }


### PR DESCRIPTION
Here a bit tricky code. Let me start from use-case.

Let image that I made a library that should be compiled to JS code which checking in runtime where it is running: on DOM, NodeJS, etc.

Some features inside nodeJS are available only via requirements.

Right now it is possibly to get access to it via `js.Dynamic.global`.

But it isn't possible to get access via typed like `@JSImport` because it fails on linking with error like:
```
Unsupported input: List(CommonJSModule([some path]/main.js))
```

So, here a trivial changes that allows to mix `withModuleKind(ModuleKind.CommonJSModule)` with this `jsEnv`.

I also added a test to proove that it works, and explain how it works.