### PR TITLE
Update scalajs-js-envs to 1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,11 +69,11 @@ lazy val `scalajs-env-jsdom-nodejs`: Project = project.in(file("jsdom-nodejs-env
     commonSettings,
 
     libraryDependencies ++= Seq(
-      "org.scala-js" %% "scalajs-js-envs" % scalaJSVersion,
-      "org.scala-js" %% "scalajs-env-nodejs" % scalaJSVersion,
+      "org.scala-js" %% "scalajs-js-envs" % MetaBuildShared.scalajsJsEnvsVersion,
+      "org.scala-js" %% "scalajs-env-nodejs" % MetaBuildShared.scalajsJsEnvsVersion,
 
       "com.novocode" % "junit-interface" % "0.11" % "test",
-      "org.scala-js" %% "scalajs-js-envs-test-kit" % scalaJSVersion % "test"
+      "org.scala-js" %% "scalajs-js-envs-test-kit" % MetaBuildShared.scalajsJsEnvsVersion % "test"
     )
   )
 

--- a/project/MetaBuildShared.scala
+++ b/project/MetaBuildShared.scala
@@ -1,0 +1,6 @@
+// this file is shared between the build and the meta-build
+// the file is located in project/ and there is a system link
+// to it in project/project/
+object MetaBuildShared {
+  val scalajsJsEnvsVersion = "1.4.0"
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
-libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.0.1"
+libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % MetaBuildShared.scalajsJsEnvsVersion
 
 unmanagedSourceDirectories in Compile +=
   baseDirectory.value.getParentFile / "jsdom-nodejs-env/src/main/scala"

--- a/project/project/MetaBuildShared.scala
+++ b/project/project/MetaBuildShared.scala
@@ -1,0 +1,1 @@
+../MetaBuildShared.scala


### PR DESCRIPTION
This is needed to fix this issue https://github.com/scala-js/scala-js-js-envs/issues/12 that is fixed in the latest version of `scalajs-env-nodejs` To share the version between build and meta-build I created a Scala file which I then syslinked to project/project/ by doing:
```
cd project/project
ln -s ../MetaBuildShared.scala
```